### PR TITLE
fix: only set highlights when colorscheme is set

### DIFF
--- a/colors/darkvoid.lua
+++ b/colors/darkvoid.lua
@@ -1,1 +1,1 @@
-require("darkvoid").setup()
+require("darkvoid").load()

--- a/lua/darkvoid/colors.lua
+++ b/lua/darkvoid/colors.lua
@@ -53,6 +53,10 @@ M.config = {
 	},
 }
 
+M.extend = function(user_config)
+  M.config = vim.tbl_deep_extend("force", M.config, user_config or {})
+end
+
 -- Apply the colorscheme (using defined colors and groups)
 function M.setup(user_config)
 	-- Merge user configuration with default (optional)

--- a/lua/darkvoid/init.lua
+++ b/lua/darkvoid/init.lua
@@ -1,11 +1,21 @@
 local M = {}
 
 M.setup = function(user_config)
-	-- for colorscheme
-	require("darkvoid.colors").setup(user_config)
+  require("darkvoid.colors").extend(user_config or {})
+end
 
+M.load = function(user_config)
+  local config = require("darkvoid.colors").config
+  if user_config then
+    vim.tbl_deep_extend("force", config, user_config)
+  end
+
+  vim.cmd("highlight clear")
+
+	-- for colorscheme
+	require("darkvoid.colors").setup(config)
 	-- for config
-	require("darkvoid.config").setup(user_config)
+	require("darkvoid.config").setup(config)
 end
 
 return M


### PR DESCRIPTION
Changes the `darkvoid.setup` function to only modify the config.
Instead of calling `darkvoid.setup` when the colorscheme is loaded using `coloscheme darkvoid`, a new function `darkvoid.load` is called, which sets all the highlights. Also added `vim.cmd("colorscheme clear")` before the highlights are set so that the colorscheme can be properly applied after another colorscheme has been loaded.