### PR TITLE
feat: support for nvim-notify

### DIFF
--- a/config.md
+++ b/config.md
@@ -40,6 +40,7 @@ require('darkvoid').setup({
             bufferline = true,
             oil = true,
             whichkey = true,
+            nvim_notify = true,
         },
 
         -- gitsigns colors

--- a/lua/darkvoid/colors.lua
+++ b/lua/darkvoid/colors.lua
@@ -36,6 +36,7 @@ M.config = {
 			bufferline = true,
 			oil = true,
 			whichkey = true,
+			nvim_notify = true,
 		},
 
 		-- gitsigns colors

--- a/lua/darkvoid/config.lua
+++ b/lua/darkvoid/config.lua
@@ -12,6 +12,7 @@ local function load_plugins(colors, config)
 		"oil",
 		"nvim-cmp",
 		"whichkey",
+		"nvim_notify",
 		-- more plugins can be added here
 	}
 

--- a/lua/darkvoid/plugins/nvim_notify.lua
+++ b/lua/darkvoid/plugins/nvim_notify.lua
@@ -1,0 +1,44 @@
+local M = {}
+
+M.setup = function()
+	local colors = require("darkvoid.colors").config.colors
+
+	local enabled = require("darkvoid.colors").config.colors.plugins.nvim_notify
+
+	if not enabled then
+		return
+	end
+
+	local highlight_groups = {
+		NotifyERRORBorder = { fg = colors.error, bg = "NONE" },
+		NotifyWARNBorder = { fg = colors.warn, bg = "NONE" },
+		NotifyINFOBorder = { fg = colors.info, bg = "NONE" },
+		NotifyDEBUGBorder = { fg = colors.info, bg = "NONE" },
+		NotifyTRACEBorder = { fg = colors.info, bg = "NONE" },
+
+		NotifyERRORIcon = { fg = colors.error, bg = "NONE" },
+		NotifyWARNIcon = { fg = colors.warn, bg = "NONE" },
+		NotifyINFOIcon = { fg = colors.info, bg = "NONE" },
+		NotifyDEBUGIcon = { fg = colors.info, bg = "NONE" },
+		NotifyTRACEIcon = { fg = colors.info, bg = "NONE" },
+
+		NotifyERRORTitle = { fg = colors.error, bg = "NONE" },
+		NotifyWARNTitle = { fg = colors.warn, bg = "NONE" },
+		NotifyINFOTitle = { fg = colors.info, bg = "NONE" },
+		NotifyDEBUGTitle = { fg = colors.info, bg = "NONE" },
+		NotifyTRACETitle = { fg = colors.info, bg = "NONE" },
+	}
+
+	for group_name, config in pairs(highlight_groups) do
+		local cmd = "highlight " .. group_name
+		if config.fg then
+			cmd = cmd .. " guifg=" .. config.fg
+		end
+		if config.bg then
+			cmd = cmd .. " guibg=" .. config.bg
+		end
+		vim.cmd(cmd)
+	end
+end
+
+return M


### PR DESCRIPTION
To test/validate this PR:

1. Install [nvim-notify](https://github.com/rcarriga/nvim-notify)
2. Point this theme's setup to this branch

```
{
  "windowsrefund/darkvoid.nvim",
  branch = "nvim-notify",
},
```
3. Generate some notifications

```
:lua require("notify")("info message")

:lua require("notify")("warning message", "warn")

:lua require("notify")("error message", "error")
```