### PR TITLE
Set vim.g.colors_name to prevent LazyVim from throwing an error

### DIFF
--- a/lua/darkvoid/init.lua
+++ b/lua/darkvoid/init.lua
@@ -1,16 +1,23 @@
 local M = {}
 
 M.setup = function(user_config)
-  require("darkvoid.colors").extend(user_config or {})
+	require("darkvoid.colors").extend(user_config or {})
 end
 
 M.load = function(user_config)
-  local config = require("darkvoid.colors").config
-  if user_config then
-    vim.tbl_deep_extend("force", config, user_config)
-  end
+	local config = require("darkvoid.colors").config
+	if user_config then
+		vim.tbl_deep_extend("force", config, user_config)
+	end
 
-  vim.cmd("highlight clear")
+	-- we only need to run this if another theme is already set
+	-- otherwise, assume it's a clean slate
+	if vim.g.colors_name then
+		vim.cmd("highlight clear")
+	end
+
+	vim.g.colors_name = "darkvoid"
+	vim.o.termguicolors = true
 
 	-- for colorscheme
 	require("darkvoid.colors").setup(config)


### PR DESCRIPTION
Also set vim.o.termguicolors to true, which will give users greater flexibility in setting their own colors through the config function; this should make the theme more friendly for users that are still new to Neovim.

Fixes #10 

