### PR TITLE
New config option: Special highlight group

### DIFF
--- a/config.md
+++ b/config.md
@@ -30,6 +30,7 @@ require('darkvoid').setup({
         preprocessor = "#4b8902",
         bool = "#66b2b2",
         constant = "#b2d8d8",
+        special = "#8cf8f7",
 
         -- enable or disable specific plugin highlights
         plugins = {

--- a/lua/darkvoid/colors.lua
+++ b/lua/darkvoid/colors.lua
@@ -25,6 +25,7 @@ M.config = {
 		preprocessor = "#4b8902",
 		bool = "#66b2b2",
 		constant = "#b2d8d8",
+		special = "#8cf8f7",
 
 		-- enable or disable specific plugin highlights
 		plugins = {
@@ -94,6 +95,7 @@ function M.setup(user_config)
 		PreProc = { fg = colors.preprocessor },
 		Boolean = { fg = colors.bool },
 		Constant = { fg = colors.constant },
+		Special = { fg = colors.special },
 
 		Search = { fg = colors.search_highlight, bg = "NONE", gui = "bold" },
 		IncSearch = { fg = colors.search_highlight, bg = "NONE", gui = "bold" },


### PR DESCRIPTION
Added a new config option, `colors.special`, which is applied to the `Special` highlight group. The default color of `colors.special` is the "glowy blue" that the old `type_builtin` has in the config documentation. Also updated the config documentation to include the new option. 

I tested setting `colors.special` to some different colors in the config, which worked as expected. I also testing omitting the option, which set it to the default value I added, meaning this feature will not break any existing configs. 

> Note: I'm not married to the actual color I picked for the default here; I just care about the feature. You should change this color to something else if you prefer a slightly color as the default. 

Fixes #15 